### PR TITLE
add auth_version=3 if api_version=3

### DIFF
--- a/hooks/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/hooks/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -6,6 +6,8 @@ auth_type = password
 {% if api_version == "3" -%}
 project_domain_name = {{ admin_domain_name }}
 user_domain_name = {{ admin_domain_name }}
+# workaround for LP#1702278
+auth_version = 3
 {% else -%}
 project_domain_name = default
 user_domain_name = default


### PR DESCRIPTION
When the cloud is deployed or upgraded with keystone
parameter preferred-api-version=3, auth_version=3
parameter should also be set in [keystone_authtoken]
section of neutron conf. This is also a requirement for
Cisco ACI integration i.e. for cisco group-based-policy
plugin to send v3 requests to keystone.

Workaround for LP#1702278