### PR TITLE
Completely revert lp1830536 "Ensure that only cloud admins are neutron admins"

### DIFF
--- a/hooks/neutron_api_utils.py
+++ b/hooks/neutron_api_utils.py
@@ -464,13 +464,6 @@ def resource_map(release=None):
     release = release or os_release('neutron-common')
 
     resource_map = deepcopy(BASE_RESOURCE_MAP)
-    if CompareOpenStackReleases(release) >= 'queens':
-        resource_map[ADMIN_POLICY] = {
-            'contexts': [
-                neutron_api_context.IdentityServiceContext(
-                    service='neutron',
-                    service_user='neutron')],
-            'services': ['neutron-server']}
     if CompareOpenStackReleases(release) >= 'liberty':
         resource_map.update(LIBERTY_RESOURCE_MAP)
 

--- a/templates/queens/00-admin.json
+++ b/templates/queens/00-admin.json
@@ -1,2 +1,0 @@
-"is_service_project": "project_id:{{ service_project_id }} or domain_id:{{ service_domain_id }}"
-"context_is_admin": "role:admin and (is_admin_project:True or rule:is_service_project)"

--- a/unit_tests/test_neutron_api_utils.py
+++ b/unit_tests/test_neutron_api_utils.py
@@ -205,7 +205,7 @@ class TestNeutronAPIUtils(CharmTestCase):
         _map = nutils.resource_map()
         confs = [nutils.NEUTRON_CONF, nutils.NEUTRON_DEFAULT,
                  nutils.APACHE_CONF, nutils.NEUTRON_LBAAS_CONF,
-                 nutils.NEUTRON_VPNAAS_CONF, nutils.ADMIN_POLICY]
+                 nutils.NEUTRON_VPNAAS_CONF]
         [self.assertIn(q_conf, _map.keys()) for q_conf in confs]
         self.assertTrue(nutils.APACHE_24_CONF not in _map.keys())
 


### PR DESCRIPTION
In lp:1830536 an admin policy json was added as a fix, but later
reverted as it was creating regressions. The reversion was added as Change-Id:
I161ea7d1aec5e5784455b5bce4605b2f9143daa2, commit f33b6789acac63ebb15e6a01a2a0c60e62d9d076

While adding ACI patches the reversion was partially reverted again. This fix aims to complete the reversion.